### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 wordpress/*
+_site/


### PR DESCRIPTION
Adding _site to this list because the repository only needs the Jekyll source of the website and not necessarily the compiled HTML, unless you think otherwise.
